### PR TITLE
wrap levels and return typed logger

### DIFF
--- a/log/core_logger.go
+++ b/log/core_logger.go
@@ -1,0 +1,38 @@
+package log
+
+import "github.com/go-kit/kit/log/levels"
+
+type CoreLogger struct {
+	levels.Levels
+}
+
+func NewCoreLogger(l levels.Levels) *CoreLogger {
+	return &CoreLogger{Levels: l}
+}
+
+func (cl *CoreLogger) LogInfoMessage(message string, keyvalues ...interface{}) {
+	cl.LogInfo(append(keyvalues, "msg", message)...)
+}
+
+func (cl *CoreLogger) LogErrorMessage(message string, keyvalues ...interface{}) {
+	cl.LogError(append(keyvalues, "msg", message)...)
+}
+
+func (cl *CoreLogger) LogInfo(keyvals ...interface{}) {
+	if len(keyvals) == 1 {
+		keyvals = []interface{}{"msg", keyvals[0]}
+	}
+	cl.Levels.Info(encodeCompoundValues(keyvals...)...)
+}
+
+func (cl *CoreLogger) LogError(keyvals ...interface{}) {
+	if len(keyvals) == 1 {
+		keyvals = []interface{}{"msg", keyvals[0]}
+	}
+	cl.Levels.Error(encodeCompoundValues(keyvals...)...)
+}
+
+func (cl *CoreLogger) SetStandardFields(keyvals ...interface{}) {
+	encoded := encodeCompoundValues(keyvals...)
+	cl.Levels = cl.Levels.With(encoded...)
+}

--- a/log/log.go
+++ b/log/log.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"time"
 
 	kitlog "github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/levels"
 )
 
 var (
-	GlobalLogger levels.Levels // level based logger
+	GlobalLogger *CoreLogger // level based logger
 )
 
 // Public initialization function to initialize the logger global.
@@ -18,7 +19,7 @@ var (
 // This should be called before any goroutines using the logger are started
 func SetupLogFmtLoggerTo(writer io.Writer) {
 	l := LogfmtLoggerTo(writer)
-	l = l.With("aaats", kitlog.DefaultTimestampUTC)
+	l.SetStandardFields("aaats", defaultTimeUTC())
 	GlobalLogger = l
 }
 
@@ -29,47 +30,41 @@ func SetupJSONLoggerTo(writer io.Writer) {
 	l := JSONLoggerTo(writer)
 	// cloudwatch takes the first instance of a timestamp matching the format.
 	// the json logger sorts alphabetically, so this ensures its first
-	l = l.With("aaats", kitlog.DefaultTimestampUTC)
+	l.SetStandardFields("aaats", defaultTimeUTC())
 	GlobalLogger = l
 }
 
 // Log a message to Info, with optional keyvalues
 func LogInfoMessage(message string, keyvalues ...interface{}) {
-	LogInfo(append(keyvalues, "msg", message)...)
+	GlobalLogger.LogInfoMessage(message, keyvalues...)
 }
 
 // Log a message to Error, with optional keyvalues
 func LogErrorMessage(message string, keyvalues ...interface{}) {
-	LogError(append(keyvalues, "msg", message)...)
+	GlobalLogger.LogErrorMessage(message, keyvalues...)
 }
 
 // Log a series of key, values to Info
 func LogInfo(keyvals ...interface{}) {
-	if len(keyvals) == 1 {
-		keyvals = []interface{}{"msg", keyvals[0]}
-	}
-	GlobalLogger.Info(encodeCompoundValues(keyvals...)...)
+	GlobalLogger.LogInfo(keyvals...)
 }
 
 // Log a series of key, values to Error
 func LogError(keyvals ...interface{}) {
-	if len(keyvals) == 1 {
-		keyvals = []interface{}{"msg", keyvals[0]}
-	}
-	GlobalLogger.Error(encodeCompoundValues(keyvals...)...)
+	GlobalLogger.LogError(keyvals...)
 }
 
 // Sets standard fields on the logger, for all calls
 func SetStandardFields(keyvals ...interface{}) {
-	GlobalLogger = GlobalLogger.With(encodeCompoundValues(keyvals...)...)
+	GlobalLogger.SetStandardFields(keyvals...)
 }
 
-func JSONLoggerTo(writer io.Writer) levels.Levels {
-	return levels.New(kitlog.NewJSONLogger(writer))
+func JSONLoggerTo(writer io.Writer) *CoreLogger {
+	return NewCoreLogger(levels.New(kitlog.NewJSONLogger(writer)))
 }
 
-func LogfmtLoggerTo(writer io.Writer) levels.Levels {
-	return levels.New(kitlog.NewLogfmtLogger(writer))
+func LogfmtLoggerTo(writer io.Writer) *CoreLogger {
+	return NewCoreLogger(levels.New(kitlog.NewLogfmtLogger(writer)))
 }
 
 // Encode compound values using %+v. To use a custom encoding, use a type that implements fmt.Stringer
@@ -90,9 +85,13 @@ func encodeCompoundValues(keyvals ...interface{}) []interface{} {
 	return keyvals
 }
 
+func defaultTimeUTC() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
 // Package-level default initialization of the logger.
 // Initializes it to a no-op implementation;
 // later calls can replace it by calling SetupLogger.
 func init() {
-	GlobalLogger = levels.New(kitlog.NewNopLogger())
+	GlobalLogger = NewCoreLogger(levels.New(kitlog.NewNopLogger()))
 }


### PR DESCRIPTION
Made a type CoreLogger to wrap our levels.Levels.

This means we can return something with a known type, that implements interface we're looking for.

The global logger calls just call down through.
