### PR TITLE
A metrics recorder for writing to multiple statsd endpoints.

### DIFF
--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -30,6 +30,13 @@ func TestGetStatsdMetric(t *testing.T) {
 	metrics.IncrementCount("countMetric")
 }
 
+func TestGetMultiStatsdMetric(t *testing.T) {
+	sd, _ := metrics.NewMultiStatsdRecorder([]string{"127.0.0.1:8888", "127.0.0.1:8889"}, "namespace")
+	sd.IncrementCount("countMetric") // doesn't panic
+	metrics.SetMetricsGlobal(sd)
+	metrics.IncrementCount("countMetric")
+}
+
 type TestRecorder struct {
 	metrics map[string]interface{}
 }

--- a/metrics/multi_statsd_recorder.go
+++ b/metrics/multi_statsd_recorder.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/armon/go-metrics"
+)
+
+// A MetricsRecorder implementation which is just a wrapper around
+// the go-metrics library, to record to Statsd.
+type MultiStatsdRecorder struct {
+	Metrics []*metrics.Metrics
+	prefix  string
+}
+
+// Takes a slice of host:port strings of the statsite endpoints to write to.
+func NewMultiStatsdRecorder(statsiteEndpoints []string, namespace string) (*MultiStatsdRecorder, error) {
+	recorder := &MultiStatsdRecorder{}
+	for i, endpoint := range statsiteEndpoints {
+		if endpoint == "" {
+			return nil, fmt.Errorf("Uninitialized MultiStatsdRecorder %d", i)
+		}
+		// statsdsink can be used to send to statssite over UDP
+		// https://github.com/armon/go-metrics/blob/master/statsd.go#L21
+		sink, _ := metrics.NewStatsdSink(endpoint)
+		config := metrics.DefaultConfig(namespace)
+		config.EnableHostname = false
+		m, _ := metrics.New(config, sink)
+		recorder.Metrics = append(recorder.Metrics, m)
+	}
+	return recorder, nil
+}
+
+func (m *MultiStatsdRecorder) IncrementCount(metricName string) {
+	for _, recorder := range m.Metrics {
+		recorder.IncrCounter(m.prefixedMetricName(metricName), 1)
+	}
+}
+
+func (m *MultiStatsdRecorder) IncrementCountBy(metricName string, amount int) {
+	for _, recorder := range m.Metrics {
+		recorder.IncrCounter(m.prefixedMetricName(metricName), float32(amount))
+	}
+}
+
+func (m *MultiStatsdRecorder) MeasureSince(metricName string, since time.Time) {
+	for _, recorder := range m.Metrics {
+		recorder.MeasureSince(m.prefixedMetricName(metricName), since)
+	}
+}
+
+func (m *MultiStatsdRecorder) SetGauge(metricName string, val float32) {
+	for _, recorder := range m.Metrics {
+		recorder.SetGauge(m.prefixedMetricName(metricName), val)
+	}
+}
+
+func (m *MultiStatsdRecorder) SetPrefix(prefix string) {
+	m.prefix = prefix
+}
+
+func (m *MultiStatsdRecorder) prefixedMetricName(metricName string) []string {
+	if m.prefix == "" {
+		return []string{metricName}
+	}
+	return []string{m.prefix, metricName}
+}


### PR DESCRIPTION
As we're evaluating datadog for metrics recording we need to dual-write metrics to our existing statsd endpoint and their statsd.
