### PR TITLE
Fix capturing errors with tags on global monitor

### DIFF
--- a/monitoring/monitoring.go
+++ b/monitoring/monitoring.go
@@ -28,5 +28,5 @@ func CaptureException(err error) {
 
 // Capture an exception with tags
 func CaptureExceptionWithTags(err error, tags ...interface{}) {
-	globalMonitor.CaptureExceptionWithTags(err, tags)
+	globalMonitor.CaptureExceptionWithTags(err, tags...)
 }


### PR DESCRIPTION
<img width="894" alt="screenshot 2016-07-13 16 56 45" src="https://cloud.githubusercontent.com/assets/1917451/16810152/cfce67c2-491a-11e6-90fc-1c6843c08e61.png">
