### PR TITLE
copy timestamp setting for logger

### DIFF
--- a/log/core_logger.go
+++ b/log/core_logger.go
@@ -39,11 +39,13 @@ func (cl *CoreLogger) LogError(keyvals ...interface{}) {
 
 func (cl *CoreLogger) SetStandardFields(keyvals ...interface{}) *CoreLogger {
 	encoded := encodeCompoundValues(keyvals...)
-	return NewCoreLogger(cl.Levels.With(encoded...))
+	newLogger := NewCoreLogger(cl.Levels.With(encoded...))
+	newLogger.UseTimestamp(cl.useTimestamp)
+	return newLogger
 }
 
 func (cl *CoreLogger) UseTimestamp(shouldUse bool) {
-	cl.useTimestamp = true
+	cl.useTimestamp = shouldUse
 }
 
 func (cl *CoreLogger) logTimestamp(keyvals []interface{}) []interface{} {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -66,6 +66,16 @@ func TestLogWithStandardFields(t *testing.T) {
 	checkLogFormatMatches(t, "level=info foo=bar key=4 msg=something\n", buf)
 }
 
+func TestLogWithStandardFieldsAndTimestamp(t *testing.T) {
+	buf := bytes.Buffer{}
+	SetupJSONLoggerTo(&buf)
+
+	UseTimestamp(true)
+	SetStandardFields("foo", "bar")
+	LogErrorMessage("uh oh")
+	assertTimestampWithin(t, &buf)
+}
+
 func TestLogWithStandardFieldsMakesNewLogger(t *testing.T) {
 	buf := bytes.Buffer{}
 	logger := LogfmtLoggerTo(&buf)
@@ -92,6 +102,10 @@ func TestJSONLogWithTimestamp(t *testing.T) {
 	UseTimestamp(true)
 
 	LogInfoMessage("something", "key", 4)
+	assertTimestampWithin(t, &buf)
+}
+
+func assertTimestampWithin(t *testing.T, buf *bytes.Buffer) {
 	tsl := timestampedLog{}
 	json.Unmarshal(buf.Bytes(), &tsl)
 	have := tsl.Timestamp.Unix()


### PR DESCRIPTION
previously the timestamp setting wasn't copied across to the new logger when standard fields were set.