### PR TITLE
events

### DIFF
--- a/events/event.go
+++ b/events/event.go
@@ -1,0 +1,51 @@
+package events
+
+import "sync"
+
+// Event wraps some data and some sinks to send it to.
+type Event struct {
+	*sync.RWMutex
+	Name   string
+	fields map[string]interface{}
+	sinks  []EventSink
+}
+
+// EventSink defines an interface for accepting data for an event
+type EventSink interface {
+	SendEvent(eventName string, fields map[string]interface{})
+}
+
+func NewEvent(name string, sinks ...EventSink) *Event {
+	return &Event{RWMutex: &sync.RWMutex{}, Name: name, fields: map[string]interface{}{}, sinks: sinks}
+}
+
+// Send event to all sinks asynchronously
+func (event *Event) Send() {
+	for _, sink := range event.sinks {
+		go sink.SendEvent(event.Name, event.getFieldsCopy())
+	}
+}
+
+// Send to a particular event sink asynchronously, won't send to other sinks defined on the event prior
+func (event *Event) SendTo(sink EventSink) {
+	go sink.SendEvent(event.Name, event.getFieldsCopy())
+}
+
+// Add a field to this event
+func (event *Event) AddField(key string, value interface{}) {
+	event.Lock()
+	defer event.Unlock()
+	event.fields[key] = value
+}
+
+// Get a copy of the fields for this event
+func (event *Event) getFieldsCopy() map[string]interface{} {
+	event.RLock()
+	defer event.RUnlock()
+
+	copyFields := map[string]interface{}{}
+	for key, value := range event.fields {
+		copyFields[key] = value
+	}
+	return copyFields
+}

--- a/events/event_test.go
+++ b/events/event_test.go
@@ -1,0 +1,57 @@
+package events
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewEvent(t *testing.T) {
+	sink := &testSink{t: t, events: make(chan string)}
+	event := NewEvent("name", sink)
+	if event.Name != "name" {
+		t.Errorf("name not set")
+	}
+
+	event.AddField("foo", "bar")
+	event.Send()
+	sent := <-sink.events
+	if sent != "name - map[foo:bar]" {
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+}
+
+func TestEventSendTo(t *testing.T) {
+	sink := &testSink{t: t, events: make(chan string)}
+	event := NewEvent("name")
+	event.AddField("foo", "bar")
+	event.SendTo(sink)
+	sent := <-sink.events
+	if sent != "name - map[foo:bar]" {
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+}
+
+func TestEventTwoSinks(t *testing.T) {
+	sink := &testSink{t: t, events: make(chan string)}
+	event := NewEvent("name", sink, sink)
+	event.AddField("foo", "bar")
+	event.Send()
+	sent := <-sink.events
+	if sent != "name - map[foo:bar]" {
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+
+	sent = <-sink.events
+	if sent != "name - map[foo:bar]" {
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+}
+
+type testSink struct {
+	t      *testing.T
+	events chan string
+}
+
+func (sink *testSink) SendEvent(eventName string, fields map[string]interface{}) {
+	sink.events <- fmt.Sprintf("%s - %v", eventName, fields)
+}

--- a/events/honeycomb_event.go
+++ b/events/honeycomb_event.go
@@ -1,0 +1,21 @@
+package events
+
+import libhoney "github.com/honeycombio/libhoney-go"
+
+// HoneycombSink will send the event to HoneyComb.io, with fields added.
+type HoneycombSink struct {
+	builder *libhoney.Builder
+}
+
+func NewHoneycombSink(builder *libhoney.Builder) *HoneycombSink {
+	return &HoneycombSink{builder: builder}
+}
+
+func (sink *HoneycombSink) SendEvent(eventName string, fields map[string]interface{}) {
+	honeyEvent := sink.builder.NewEvent()
+	honeyEvent.AddField("name", eventName)
+	for key, value := range fields {
+		honeyEvent.AddField(key, value)
+	}
+	honeyEvent.Send()
+}

--- a/events/log_sink.go
+++ b/events/log_sink.go
@@ -1,0 +1,20 @@
+package events
+
+import "github.com/intercom/gocore/log"
+
+// LogEventSink will log the event with level "info" to the logger passed in, using the event fields.
+type LogEventSink struct {
+	logger log.Logger
+}
+
+func NewLogEventSink(logger log.Logger) *LogEventSink {
+	return &LogEventSink{logger: logger}
+}
+
+func (sink *LogEventSink) SendEvent(eventName string, fields map[string]interface{}) {
+	keyVals := []interface{}{}
+	for key, value := range fields {
+		keyVals = append(keyVals, []interface{}{key, value})
+	}
+	sink.logger.LogInfoMessage(eventName, keyVals...)
+}


### PR DESCRIPTION
Events map well to a few different things we already measure here. For example, an event might be a new request coming in, or a notification that something failed, or that it took some amount of time. This PR proposes we use a unified event concept, and then add different sinks for output to different systems.

I think an event at a minimum has a name and a list of fields that are essentially metadata about the event. In the case of a logging sink, the event name would be the log message, and the fields translate to structured log fields. For a honeycomb event, the name would just be another field along with the other field data. For a future metrics (statsd) sink, the name would be the metric name, the fields map well to tags, and then we'd have to decide some means of deciding whether it's a count, time measurement etc (deferring this decision for now).

```go
// some setup
logsink := events.NewLogEventSink(coreapi.GetLogger(r))
honeycombsink := events.NewHoneycombSink(honeyCombBuilder)

// then send events
event := events.NewEvent("request_error", logsink, honeycombsink)
event.AddField("request_id", coreapi.GetRequestID(r))
event.AddField("err_message", e)
event.Send()

// can also send to specific sinks only
event.SendTo(logsink2)
```