### PR TITLE
dynamic event fields

### DIFF
--- a/events/event_test.go
+++ b/events/event_test.go
@@ -47,6 +47,53 @@ func TestEventTwoSinks(t *testing.T) {
 	}
 }
 
+func TestDynamicField(t *testing.T) {
+	sink := &testSink{t: t, events: make(chan string)}
+	event := NewEvent("name", sink)
+
+	i := 0
+	fn := func() interface{} {
+		i += 1
+		return i
+	}
+	event.AddDynamicField("foo", fn)
+
+	event.Send()
+	sent := <-sink.events
+	if sent != "name - map[foo:1]" {
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+
+	event.Send()
+	sent = <-sink.events
+	if sent != "name - map[foo:2]" { // different result as different sends
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+}
+
+func TestDynamicFieldTwoSinks(t *testing.T) {
+	sink := &testSink{t: t, events: make(chan string)}
+	event := NewEvent("name", sink, sink)
+
+	i := 0
+	fn := func() interface{} {
+		i += 1
+		return i
+	}
+	event.AddDynamicField("foo", fn)
+
+	event.Send()
+	sent := <-sink.events
+	if sent != "name - map[foo:1]" {
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+
+	sent = <-sink.events
+	if sent != "name - map[foo:1]" { // same result as multiple sends at once
+		t.Errorf("did not send event properly to sink %s", sent)
+	}
+}
+
 type testSink struct {
 	t      *testing.T
 	events chan string


### PR DESCRIPTION
This makes measuring things such as durations much easier as instead of having to manually track event started time then apply at the end, it can be evaluated in a closure. Here's an example of using this to add a duration in milliseconds (as a float):

```go
startTime := time.Now()
fn := func() interface{} {
	elapsed := time.Now().Sub(startTime)
	return float32(elapsed.Nanoseconds()) / float32(time.Millisecond)
}
event.AddDynamicField("duration_ms", fn)
```