### PR TITLE
update logging so works with latest gokit

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,25 +177,3 @@ type UserResponse struct {
 	Email string `json:"email"`
 }
 ``` 
-
-
-#### Dependencies
-
-GoKit Log, Levels:
-
-```
-"github.com/go-kit/kit/log"
-"github.com/go-kit/kit/log/levels"
-```
-
-Armon/Go-Metrics:
-
-```
-"github.com/armon/go-metrics"
-```
-
-Sentry/Raven:
-
-```
-"github.com/getsentry/raven-go"
-```

--- a/log/adapter.go
+++ b/log/adapter.go
@@ -1,0 +1,62 @@
+package log
+
+import (
+	"io"
+	"regexp"
+	"time"
+)
+
+func NewWriterToLog(log Logger) io.Writer {
+	return &StdlibAdapter{Logger: log}
+}
+
+type StdlibAdapter struct {
+	Logger Logger
+}
+
+func (a *StdlibAdapter) Write(p []byte) (int, error) {
+	result := a.subexps(p)
+	keyvals := []interface{}{}
+	var timestamp string
+	if date, ok := result["date"]; ok && date != "" {
+		timestamp = date
+	}
+	if time, ok := result["time"]; ok && time != "" {
+		if timestamp != "" {
+			timestamp += " "
+		}
+		timestamp += time
+	}
+	if timestamp != "" {
+		t, _ := time.Parse("2006/01/02 15:04:05", timestamp)
+		keyvals = append(keyvals, "timestamp", t)
+	}
+	if msg, ok := result["msg"]; ok {
+		keyvals = append(keyvals, "msg", msg)
+	}
+	a.Logger.LogError(keyvals...)
+	return len(p), nil
+}
+
+const (
+	logRegexpDate = `(?P<date>[0-9]{4}/[0-9]{2}/[0-9]{2})?[ ]?`
+	logRegexpTime = `(?P<time>[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?)?[ ]?`
+	logRegexpFile = `(?P<file>.+?:[0-9]+)?`
+	logRegexpMsg  = `(: )?(?P<msg>.*)`
+)
+
+var (
+	logRegexp = regexp.MustCompile(logRegexpDate + logRegexpTime + logRegexpFile + logRegexpMsg)
+)
+
+func (a *StdlibAdapter) subexps(line []byte) map[string]string {
+	m := logRegexp.FindSubmatch(line)
+	if len(m) < len(logRegexp.SubexpNames()) {
+		return map[string]string{}
+	}
+	result := map[string]string{}
+	for i, name := range logRegexp.SubexpNames() {
+		result[name] = string(m[i])
+	}
+	return result
+}

--- a/log/core_logger.go
+++ b/log/core_logger.go
@@ -3,16 +3,16 @@ package log
 import (
 	"time"
 
-	"github.com/go-kit/kit/log/levels"
+	"github.com/go-kit/kit/log"
 )
 
 type CoreLogger struct {
-	levels.Levels
+	log.Logger
 	hideTimestamp bool
 }
 
-func NewCoreLogger(l levels.Levels) *CoreLogger {
-	return &CoreLogger{Levels: l}
+func NewCoreLogger(l log.Logger) *CoreLogger {
+	return &CoreLogger{Logger: l}
 }
 
 func (cl *CoreLogger) LogInfoMessage(message string, keyvalues ...interface{}) {
@@ -27,19 +27,19 @@ func (cl *CoreLogger) LogInfo(keyvals ...interface{}) {
 	if len(keyvals) == 1 {
 		keyvals = []interface{}{"msg", keyvals[0]}
 	}
-	cl.Levels.Info().Log(encodeCompoundValues(cl.logTimestamp(keyvals)...)...)
+	cl.Logger.Log(encodeCompoundValues(append(cl.logTimestamp(keyvals), "level", "info")...)...)
 }
 
 func (cl *CoreLogger) LogError(keyvals ...interface{}) {
 	if len(keyvals) == 1 {
 		keyvals = []interface{}{"msg", keyvals[0]}
 	}
-	cl.Levels.Error().Log(encodeCompoundValues(cl.logTimestamp(keyvals)...)...)
+	cl.Logger.Log(encodeCompoundValues(append(cl.logTimestamp(keyvals), "level", "error")...)...)
 }
 
 func (cl *CoreLogger) SetStandardFields(keyvals ...interface{}) Logger {
-	encoded := encodeCompoundValues(keyvals...)
-	newLogger := NewCoreLogger(cl.Levels.With(encoded...))
+	kitLogger := log.With(cl.Logger, keyvals...)
+	newLogger := NewCoreLogger(kitLogger)
 	newLogger.hideTimestamp = cl.hideTimestamp
 	return newLogger
 }

--- a/log/log.go
+++ b/log/log.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 
 	kitlog "github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/levels"
 )
 
 var (
@@ -64,15 +63,15 @@ func SetStandardFields(keyvals ...interface{}) {
 }
 
 func JSONLoggerTo(writer io.Writer) *CoreLogger {
-	return NewCoreLogger(levels.New(kitlog.NewJSONLogger(writer)))
+	return NewCoreLogger(kitlog.NewJSONLogger(writer))
 }
 
 func LogfmtLoggerTo(writer io.Writer) *CoreLogger {
-	return NewCoreLogger(levels.New(kitlog.NewLogfmtLogger(writer)))
+	return NewCoreLogger(kitlog.NewLogfmtLogger(writer))
 }
 
 func NoopLogger() *CoreLogger {
-	return NewCoreLogger(levels.New(kitlog.NewNopLogger()))
+	return NewCoreLogger(kitlog.NewNopLogger())
 }
 
 // Encode compound values using %+v. To use a custom encoding, use a type that implements fmt.Stringer

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -10,49 +10,49 @@ import (
 func TestLogInfo(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfo("foo", "bar")
-	checkLogFormatMatches(t, "level=info foo=bar\n", buf)
+	checkLogFormatMatches(t, "foo=bar level=info\n", buf)
 }
 
 func TestLogInfoWithOneValueBecomesMessage(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfo("foo")
-	checkLogFormatMatches(t, "level=info msg=foo\n", buf)
+	checkLogFormatMatches(t, "msg=foo level=info\n", buf)
 }
 
 func TestLogInfoMessage(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfoMessage("my message")
-	checkLogFormatMatches(t, "level=info msg=\"my message\"\n", buf)
+	checkLogFormatMatches(t, "msg=\"my message\" level=info\n", buf)
 }
 
 func TestLogInfoMessageWithExtra(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfoMessage("my message", "foo", 7)
-	checkLogFormatMatches(t, "level=info foo=7 msg=\"my message\"\n", buf)
+	checkLogFormatMatches(t, "foo=7 msg=\"my message\" level=info\n", buf)
 }
 
 func TestLogErrorMessageWithExtra(t *testing.T) {
 	buf := logWithBuffer()
 	LogErrorMessage("my message", "bar", 7.6)
-	checkLogFormatMatches(t, "level=error bar=7.6 msg=\"my message\"\n", buf)
+	checkLogFormatMatches(t, "bar=7.6 msg=\"my message\" level=error\n", buf)
 }
 
 func TestLogInfoWithCompoundTypeArray(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfo("key", []string{"foo", "bar"})
-	checkLogFormatMatches(t, "level=info key=\"[foo bar]\"\n", buf)
+	checkLogFormatMatches(t, "key=\"[foo bar]\" level=info\n", buf)
 }
 
 func TestLogInfoWithCompoundTypeMap(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfo("key", map[string]interface{}{"another": 12})
-	checkLogFormatMatches(t, "level=info key=map[another:12]\n", buf)
+	checkLogFormatMatches(t, "key=map[another:12] level=info\n", buf)
 }
 
 func TestLogInfoWithCompoundTypeStruct(t *testing.T) {
 	buf := logWithBuffer()
 	LogInfo("key", testTypeNotStringer{"foo"}, "bar", testTypeStringer{"bar"})
-	checkLogFormatMatches(t, "level=info key={Foo:foo} bar=bar\n", buf)
+	checkLogFormatMatches(t, "key={Foo:foo} bar=bar level=info\n", buf)
 }
 
 func TestLogWithStandardFields(t *testing.T) {
@@ -60,11 +60,11 @@ func TestLogWithStandardFields(t *testing.T) {
 
 	SetStandardFields("foo", "bar")
 	LogErrorMessage("uh oh")
-	checkLogFormatMatches(t, "level=error foo=bar msg=\"uh oh\"\n", buf)
+	checkLogFormatMatches(t, "foo=bar msg=\"uh oh\" level=error\n", buf)
 
 	SetStandardFields("zap", "zam")
 	LogInfoMessage("something", "key", 4)
-	checkLogFormatMatches(t, "level=info foo=bar zap=zam key=4 msg=something\n", buf)
+	checkLogFormatMatches(t, "foo=bar zap=zam key=4 msg=something level=info\n", buf)
 }
 
 func TestLogWithStandardFieldsAndTimestamp(t *testing.T) {
@@ -83,10 +83,10 @@ func TestLogWithStandardFieldsMakesNewLogger(t *testing.T) {
 	l2 := logger.SetStandardFields("foo", "bar")
 
 	logger.LogErrorMessage("uh oh")
-	checkLogFormatMatches(t, "level=error msg=\"uh oh\"\n", &buf)
+	checkLogFormatMatches(t, "msg=\"uh oh\" level=error\n", &buf)
 
 	l2.LogErrorMessage("uh oh")
-	checkLogFormatMatches(t, "level=error foo=bar msg=\"uh oh\"\n", &buf)
+	checkLogFormatMatches(t, "foo=bar msg=\"uh oh\" level=error\n", &buf)
 }
 
 func TestJSONLog(t *testing.T) {


### PR DESCRIPTION
gokit's log.levels was removed, this in turn moves back to simpler logging setup with latest gokit.